### PR TITLE
Add subversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Stuff to make the 'ack' plugin more useful
 
-It's git-aware and knows the root directory of your git repo.
+It's git and svn-aware and knows the root directory of your repo.
 
-* Maps \a to :LAck the current word starting at the git root
+* Maps \a to :LAck the current word starting at the repo root
 * Maps \A to :Ack ...
 * Maps the above, in visual mode, to use the current selection instead
   of the current word.


### PR DESCRIPTION
Adds support for Subversion, though it still checks for Git first.  Also resets `b:vcsroot` to empty string if the command exits nonzero, to avoid error text being handed to Ack.  Adds `b:vcsroot_type` which can be any of `['git', 'svn', 'none']`.
